### PR TITLE
OPENEUROPA-685: Using Alpine based images for service and pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4,7 +4,7 @@ workspace:
 
 services:
   web:
-    image: fpfis/php71-dev
+    image: fpfis/httpd-php-dev:7.1
     environment:
       - DOCUMENT_ROOT=/test/europa-demo
   mysql:
@@ -22,14 +22,14 @@ services:
 pipeline:
   composer-install:
     group: prepare
-    image: fpfis/php71-build
+    image: fpfis/httpd-php-dev:7.1
     volumes:
       - /cache:/cache
     commands:
       - composer install
 
   site-install:
-    image: fpfis/php71-build
+    image: fpfis/httpd-php-dev:7.1
     commands:
       - ./vendor/bin/run drupal:site-install
       # Reset permission since installation runs as root. @todo Fix this.
@@ -50,12 +50,12 @@ pipeline:
 
   grumphp:
     group: test
-    image: fpfis/php71-build
+    image: fpfis/httpd-php-dev:7.1
     commands:
       - ./vendor/bin/grumphp run
 
   behat:
     group: test
-    image: fpfis/php71-build
+    image: fpfis/httpd-php-dev:7.1
     commands:
       - ./vendor/bin/behat

--- a/.drone.yml
+++ b/.drone.yml
@@ -7,10 +7,6 @@ services:
     image: fpfis/httpd-php-dev:7.1
     environment:
       - DOCUMENT_ROOT=/test/europa-demo
-  mysql:
-    image: percona/percona-server:5.6
-    environment:
-      - MYSQL_ALLOW_EMPTY_PASSWORD=yes
   selenium:
     image: selenium/standalone-chrome:3.11
     environment:

--- a/runner.yml.dist
+++ b/runner.yml.dist
@@ -2,10 +2,11 @@ drupal:
   root: "build"
   base_url: "http://web:8080/build"
   database:
-    host: "mysql"
-    port: "3306"
-    name: "europa_demo"
-    user: "root"
+    scheme: "sqlite"
+    host: "sites/default/files"
+    port: ""
+    name: "database.sqlite"
+    user: ""
     password: ""
   site:
     profile: "config_installer"


### PR DESCRIPTION
Now using alpine based image for lower footprint

- https://github.com/fpfis/httpd-php ->  base production images 
  - tag `7.1.18` -> 7.1.18
  - tag `7.1` -> last 7.1 -> acceptance
  - tag `production-7.1` -> production
- https://github.com/fpfis/httpd-php-dev -> dev images with composer
  - tag `7.1.18` -> 7.1.18
  - tag `7.1` -> last 7.1 0
  - tag `production-7.1` -> based on production 

5.6  and 7.2 variants are available as well