### PR TITLE
OPENEUROPA-1187: Announcements block on department page.

### DIFF
--- a/sites/info/web/modules/custom/europa_demo_rdf_content/content/rdf_entity/department_energy.json
+++ b/sites/info/web/modules/custom/europa_demo_rdf_content/content/rdf_entity/department_energy.json
@@ -1,7 +1,7 @@
 {
     "_links": {
         "self": {
-            "href": "http:\/\/web:8080\/en\/rdf_entity\/http_e_f_flocalhost_e8080_fsites_finea_fweb_frdf_aentity_foe_adepartment_f9d5ebd97_b408a_b4b85_bb177_bb691abcdf6ba?_format=hal_json"
+            "href": "http:\/\/web:8080\/en\/rdf_entity\/http_e_f_flocalhost_e8080_fsites_finfo_fweb_frdf_aentity_foe_adepartment_f9d5ebd97_b408a_b4b85_bb177_bb691abcdf6ba?_format=hal_json"
         },
         "type": {
             "href": "http:\/\/drupal.org\/rest\/type\/rdf_entity\/oe_department"
@@ -32,7 +32,7 @@
     },
     "id": [
         {
-            "value": "http:\/\/localhost:8080\/sites\/inea\/web\/rdf_entity\/oe_department\/9d5ebd97-408a-4b85-b177-b691abcdf6ba"
+            "value": "http:\/\/localhost:8080\/sites\/info\/web\/rdf_entity\/oe_department\/9d5ebd97-408a-4b85-b177-b691abcdf6ba"
         }
     ],
     "rid": [
@@ -147,7 +147,7 @@
     ],
     "uuid": [
         {
-            "value": "http:\/\/localhost:8080\/sites\/inea\/web\/rdf_entity\/oe_department\/9d5ebd97-408a-4b85-b177-b691abcdf6ba"
+            "value": "http:\/\/localhost:8080\/sites\/info\/web\/rdf_entity\/oe_department\/9d5ebd97-408a-4b85-b177-b691abcdf6ba"
         }
     ],
     "langcode": [

--- a/sites/info/web/modules/custom/europa_demo_rdf_content/content/rdf_entity/department_env.json
+++ b/sites/info/web/modules/custom/europa_demo_rdf_content/content/rdf_entity/department_env.json
@@ -1,7 +1,7 @@
 {
     "_links": {
         "self": {
-            "href": "http:\/\/web:8080\/en\/rdf_entity\/http_e_f_flocalhost_e8080_fsites_finea_fweb_frdf_aentity_foe_adepartment_f02b660ea_b22af_b48e3_bbb62_bfead0269d1f6?_format=hal_json"
+            "href": "http:\/\/web:8080\/en\/rdf_entity\/http_e_f_flocalhost_e8080_fsites_finfo_fweb_frdf_aentity_foe_adepartment_f02b660ea_b22af_b48e3_bbb62_bfead0269d1f6?_format=hal_json"
         },
         "type": {
             "href": "http:\/\/drupal.org\/rest\/type\/rdf_entity\/oe_department"
@@ -35,7 +35,7 @@
     },
     "id": [
         {
-            "value": "http:\/\/localhost:8080\/sites\/inea\/web\/rdf_entity\/oe_department\/02b660ea-22af-48e3-bb62-fead0269d1f6"
+            "value": "http:\/\/localhost:8080\/sites\/info\/web\/rdf_entity\/oe_department\/02b660ea-22af-48e3-bb62-fead0269d1f6"
         }
     ],
     "rid": [
@@ -165,7 +165,7 @@
     ],
     "uuid": [
         {
-            "value": "http:\/\/localhost:8080\/sites\/inea\/web\/rdf_entity\/oe_department\/02b660ea-22af-48e3-bb62-fead0269d1f6"
+            "value": "http:\/\/localhost:8080\/sites\/info\/web\/rdf_entity\/oe_department\/02b660ea-22af-48e3-bb62-fead0269d1f6"
         }
     ],
     "langcode": [

--- a/sites/info/web/modules/custom/europa_demo_rdf_content/content/rdf_entity/department_inea.json
+++ b/sites/info/web/modules/custom/europa_demo_rdf_content/content/rdf_entity/department_inea.json
@@ -1,7 +1,7 @@
 {
     "_links": {
         "self": {
-            "href": "http:\/\/web:8080\/en\/rdf_entity\/http_e_f_flocalhost_e8080_fsites_finea_fweb_frdf_aentity_foe_adepartment_f587c717e_bcf1f_b4c74_b9b58_bd00bf04897d7?_format=hal_json"
+            "href": "http:\/\/web:8080\/en\/rdf_entity\/http_e_f_flocalhost_e8080_fsites_finfo_fweb_frdf_aentity_foe_adepartment_f587c717e_bcf1f_b4c74_b9b58_bd00bf04897d7?_format=hal_json"
         },
         "type": {
             "href": "http:\/\/drupal.org\/rest\/type\/rdf_entity\/oe_department"
@@ -38,7 +38,7 @@
     },
     "id": [
         {
-            "value": "http:\/\/localhost:8080\/sites\/inea\/web\/rdf_entity\/oe_department\/587c717e-cf1f-4c74-9b58-d00bf04897d7"
+            "value": "http:\/\/localhost:8080\/sites\/info\/web\/rdf_entity\/oe_department\/587c717e-cf1f-4c74-9b58-d00bf04897d7"
         }
     ],
     "rid": [
@@ -183,7 +183,7 @@
     ],
     "uuid": [
         {
-            "value": "http:\/\/localhost:8080\/sites\/inea\/web\/rdf_entity\/oe_department\/587c717e-cf1f-4c74-9b58-d00bf04897d7"
+            "value": "http:\/\/localhost:8080\/sites\/info\/web\/rdf_entity\/oe_department\/587c717e-cf1f-4c74-9b58-d00bf04897d7"
         }
     ],
     "langcode": [

--- a/sites/info/web/modules/custom/europa_demo_rdf_content/content/rdf_entity/site_b_event_1.json
+++ b/sites/info/web/modules/custom/europa_demo_rdf_content/content/rdf_entity/site_b_event_1.json
@@ -1,7 +1,7 @@
 {
     "_links": {
         "self": {
-            "href": "http:\/\/web:8080\/en\/rdf_entity\/http_e_f_flocalhost_e8080_fsites_finea_fweb_frdf_aentity_foe_aevent_fae827102_b2beb_b4338_b943e_b80f56358a6bf?_format=hal_json"
+            "href": "http:\/\/web:8080\/en\/rdf_entity\/http_e_f_flocalhost_e8080_fsites_finfo_fweb_frdf_aentity_foe_aevent_fae827102_b2beb_b4338_b943e_b80f56358a6bf?_format=hal_json"
         },
         "type": {
             "href": "http:\/\/drupal.org\/rest\/type\/rdf_entity\/oe_event"
@@ -35,7 +35,7 @@
     },
     "id": [
         {
-            "value": "http:\/\/localhost:8080\/sites\/inea\/web\/rdf_entity\/oe_event\/ae827102-2beb-4338-943e-80f56358a6bf"
+            "value": "http:\/\/localhost:8080\/sites\/info\/web\/rdf_entity\/oe_event\/ae827102-2beb-4338-943e-80f56358a6bf"
         }
     ],
     "rid": [
@@ -165,7 +165,7 @@
     ],
     "uuid": [
         {
-            "value": "http:\/\/localhost:8080\/sites\/inea\/web\/rdf_entity\/oe_event\/ae827102-2beb-4338-943e-80f56358a6bf"
+            "value": "http:\/\/localhost:8080\/sites\/info\/web\/rdf_entity\/oe_event\/ae827102-2beb-4338-943e-80f56358a6bf"
         }
     ],
     "langcode": [

--- a/sites/info/web/modules/custom/europa_demo_rdf_content/content/rdf_entity/site_b_event_2.json
+++ b/sites/info/web/modules/custom/europa_demo_rdf_content/content/rdf_entity/site_b_event_2.json
@@ -1,7 +1,7 @@
 {
     "_links": {
         "self": {
-            "href": "http:\/\/web:8080\/en\/rdf_entity\/http_e_f_flocalhost_e8080_fsites_finea_fweb_frdf_aentity_foe_aevent_fe424d10b_be8bc_b49c9_ba9d1_bf64511d73e6f?_format=hal_json"
+            "href": "http:\/\/web:8080\/en\/rdf_entity\/http_e_f_flocalhost_e8080_fsites_finfo_fweb_frdf_aentity_foe_aevent_fe424d10b_be8bc_b49c9_ba9d1_bf64511d73e6f?_format=hal_json"
         },
         "type": {
             "href": "http:\/\/drupal.org\/rest\/type\/rdf_entity\/oe_event"
@@ -29,7 +29,7 @@
     },
     "id": [
         {
-            "value": "http:\/\/localhost:8080\/sites\/inea\/web\/rdf_entity\/oe_event\/e424d10b-e8bc-49c9-a9d1-f64511d73e6f"
+            "value": "http:\/\/localhost:8080\/sites\/info\/web\/rdf_entity\/oe_event\/e424d10b-e8bc-49c9-a9d1-f64511d73e6f"
         }
     ],
     "rid": [
@@ -129,7 +129,7 @@
     ],
     "uuid": [
         {
-            "value": "http:\/\/localhost:8080\/sites\/inea\/web\/rdf_entity\/oe_event\/e424d10b-e8bc-49c9-a9d1-f64511d73e6f"
+            "value": "http:\/\/localhost:8080\/sites\/info\/web\/rdf_entity\/oe_event\/e424d10b-e8bc-49c9-a9d1-f64511d73e6f"
         }
     ],
     "langcode": [

--- a/sites/info/web/modules/custom/europa_demo_rdf_content/content/rdf_entity/site_b_event_3.json
+++ b/sites/info/web/modules/custom/europa_demo_rdf_content/content/rdf_entity/site_b_event_3.json
@@ -1,7 +1,7 @@
 {
     "_links": {
         "self": {
-            "href": "http:\/\/web:8080\/en\/rdf_entity\/http_e_f_flocalhost_e8080_fsites_finea_fweb_frdf_aentity_foe_aevent_fd9a9d634_b13ac_b493f_bbc18_b7b750b9698ed?_format=hal_json"
+            "href": "http:\/\/web:8080\/en\/rdf_entity\/http_e_f_flocalhost_e8080_fsites_finfo_fweb_frdf_aentity_foe_aevent_fd9a9d634_b13ac_b493f_bbc18_b7b750b9698ed?_format=hal_json"
         },
         "type": {
             "href": "http:\/\/drupal.org\/rest\/type\/rdf_entity\/oe_event"
@@ -35,7 +35,7 @@
     },
     "id": [
         {
-            "value": "http:\/\/localhost:8080\/sites\/inea\/web\/rdf_entity\/oe_event\/d9a9d634-13ac-493f-bc18-7b750b9698ed"
+            "value": "http:\/\/localhost:8080\/sites\/info\/web\/rdf_entity\/oe_event\/d9a9d634-13ac-493f-bc18-7b750b9698ed"
         }
     ],
     "rid": [
@@ -165,7 +165,7 @@
     ],
     "uuid": [
         {
-            "value": "http:\/\/localhost:8080\/sites\/inea\/web\/rdf_entity\/oe_event\/d9a9d634-13ac-493f-bc18-7b750b9698ed"
+            "value": "http:\/\/localhost:8080\/sites\/info\/web\/rdf_entity\/oe_event\/d9a9d634-13ac-493f-bc18-7b750b9698ed"
         }
     ],
     "langcode": [

--- a/themes/europa_demo_theme/europa_demo_theme.theme
+++ b/themes/europa_demo_theme/europa_demo_theme.theme
@@ -8,6 +8,8 @@
 declare(strict_types = 1);
 
 use Drupal\Core\Datetime\DrupalDateTime;
+use Drupal\Core\Url;
+use Drupal\rdf_entity\RdfInterface;
 
 /**
  * Implements hook_preprocess_menu__site_switcher().
@@ -31,19 +33,53 @@ function europa_demo_theme_preprocess_rdf_entity__oe_department(&$variables) {
   /** @var \Drupal\rdf_entity\RdfInterface $entity */
   $entity = $variables['rdf_entity'];
 
-  $variables['in_page_links'] = [
-    [
-      'href' => '#responsibilities',
-      'label' => t('Responsibilities'),
-    ],
-  ];
+  $variables['in_page_links'] = [];
 
   // Responsibilities.
+  $variables['in_page_links'][] = [
+    'href' => '#responsibilities',
+    'label' => t('Responsibilities'),
+  ];
+
   $variables['content']['oe_department_tasks_description'] = [
     '#type' => 'processed_text',
     '#text' => $entity->get('oe_department_tasks_description')->value,
     '#format' => $entity->get('oe_department_tasks_description')->format,
   ];
+
+  // Announcements.
+  $entity_type_manager = \Drupal::entityTypeManager();
+  $terms = $entity_type_manager->getStorage('taxonomy_term')->loadByProperties(['name' => ['energy policy']]);
+  $ids = array_keys($terms);
+  $ids = $entity_type_manager->getStorage('rdf_entity')->getQuery()
+    ->condition('rid', 'oe_announcement')
+    ->condition('oe_announcement_subject', $ids, 'IN')
+    ->execute();
+
+  if ($ids) {
+    $variables['in_page_links'][] = [
+      'href' => '#announcements',
+      'label' => t('News'),
+    ];
+
+    $announcements = $entity_type_manager->getStorage('rdf_entity')->loadMultiple($ids);
+    $items = [];
+    foreach ($announcements as $announcement) {
+      $items[] = europa_demo_theme_announcement_list_item($announcement);
+    }
+
+    $variables['announcements'] = [
+      '#type' => 'pattern',
+      '#id' => 'list_item_block_one_column',
+      '#items' => $items,
+    ];
+
+    if (!$entity->get('oe_department_links')->isEmpty()) {
+      $link = $entity->get('oe_department_links')->first();
+      $variables['announcements']['#button_label'] = t('All news');
+      $variables['announcements']['#button_url'] = $link->uri;
+    }
+  }
 }
 
 /**
@@ -143,4 +179,34 @@ function europa_demo_theme_preprocess_rdf_entity__oe_event(&$variables) {
   $now = new DrupalDateTime();
   $end = DrupalDateTime::createFromTimestamp($entity->get('oe_event_end_date')->value);
   $variables['passed'] = $now > $end;
+}
+
+/**
+ * Renders an Announcement in list item form.
+ *
+ * @param \Drupal\rdf_entity\RdfInterface $entity
+ *   The RDF entity.
+ *
+ * @return array
+ *   The render array.
+ */
+function europa_demo_theme_announcement_list_item(RdfInterface $entity) {
+  $build = [
+    '#type' => 'pattern',
+    '#id' => 'list_item_default',
+    '#fields' => [
+      'url' => Url::fromUri($entity->id())->toString(),
+      'title' => $entity->label(),
+    ],
+  ];
+
+  $metas = [];
+  $metas[] = $entity->get('oe_announcement_type')->entity->label();
+  $metas[] = $entity->get('oe_announcement_department')->entity->label();
+  $build['#fields']['meta'] = $metas;
+  $build['#fields']['detail'] = [
+    '#plain_text' => $entity->get('oe_announcement_introduction')->value,
+  ];
+
+  return $build;
 }

--- a/themes/europa_demo_theme/templates/rdf_entity/rdf-entity--oe-department.html.twig
+++ b/themes/europa_demo_theme/templates/rdf_entity/rdf-entity--oe-department.html.twig
@@ -26,6 +26,12 @@
       <a id="responsibilities"></a>
       <h2 class="ecl-heading ecl-heading--h2">{{ 'Responsibilities'|t }}</h2>
       {{ content.oe_department_tasks_description }}
+
+      {% if announcements %}
+        <a id="announcements"></a>
+        <h2 class="ecl-heading ecl-heading--h2">{{ 'News'|t }}</h2>
+        {{ announcements }}
+      {% endif %}
     </div>
   </div>
 </article>


### PR DESCRIPTION
Added the news (announcements) on the Department pages.

All departments show the same news with a link to read more news which goes to the link configured in the entity.

The announcements shown are those tagged with `energy policy`. This means two are shown, leaving one out tagged with `solar energy` (which is not used on the first two). 

PS: had to fix the content IDs of the department and event entities.